### PR TITLE
Поправил перезапросы в случае TCP_TIMEOUT или REQUEST_TIMEOUT

### DIFF
--- a/lib/de.request.js
+++ b/lib/de.request.js
@@ -23,10 +23,12 @@ const DEFAULT_OPTIONS = {
     max_redirects: 0,
     max_retries: 0,
     is_error: function( status_code, headers ) {
-        return ( status_code >= 400 );
+        return ( status_code === 0 || status_code >= 400 );
     },
     is_retry_allowed: function( status_code, headers ) {
         return (
+            //  0 - не получили никакого ответа (tcp_timeout или block_timeout)
+            status_code === 0 ||
             status_code === 408 ||
             status_code === 500 ||
             ( status_code >= 502 && status_code <= 504 )
@@ -260,25 +262,45 @@ de.request = function( options, context ) {
             clear_timeout();
 
             h_timeout = setTimeout( function() {
+                if ( req ) {
+                    //  Если обрываем запрос по таймауту, то надо обрывать request.
+                    //  Сокет уничтожится автоматически.
+                    req.abort();
+                }
+
+                //  Дальше решаем, что делать с запросом.
                 if ( !timestamps.tcp_connection ) {
+                    if ( do_retry( 0, {} ) ) {
+                        clear_timeout();
+                        return;
+                    }
+
                     //  Не смогли к этому моменту установить tcp-соединение.
                     do_fail( {
                         id: 'TCP_CONNECTION_TIMEOUT',
                     } );
 
                 } else {
+                    //  FIXME: тут может быть ситуация, что получили HTTP 200, но не дождались полного ответа
+                    //  FIXME: Надо ее как-то обрабатывать?
+                    if ( do_retry( 0, {} ) ) {
+                        clear_timeout();
+                        return;
+                    }
+
                     //  Тут просто слишком долго выполняли запрос целиком.
                     do_fail( {
                         id: 'REQUEST_TIMEOUT',
                     } );
                 }
-
-                if ( req ) {
-                    req.abort();
-                }
-
             }, options.timeout );
         }
+
+        const result = {
+            status_code: 0,
+            headers: {},
+            request_options: request_options,
+        };
 
         req = request_module.request( request_options, function( res ) {
             res.once( 'readable', function() {
@@ -296,11 +318,8 @@ de.request = function( options, context ) {
                 received_length += data.length;
             } );
 
-            const result = {
-                status_code: status_code,
-                headers: headers,
-                request_options: request_options,
-            };
+            result.status_code = status_code;
+            result.headers = headers;
 
             res.on( 'end', function() {
                 timestamps.end = Date.now();
@@ -356,50 +375,7 @@ de.request = function( options, context ) {
                     return;
                 }
 
-                if ( is_error( status_code, headers ) ) {
-                    if ( request_options.retries < max_retries && is_retry_allowed( status_code, headers ) ) {
-                        let log_message = status_code + in_ms( timestamps.start );
-                        if ( result.body ) {
-                            log_message += ' ' + String( result.body );
-                        }
-                        log_message += ' ' + log_url;
-                        context.warn( log_message );
-
-                        const retry_options = no.extend( {}, request_options );
-                        retry_options.retries++;
-                        retries++;
-
-                        if ( retry_timeout > 0 ) {
-                            setTimeout(
-                                function() {
-                                    do_request( retry_options );
-                                },
-                                retry_timeout
-                            );
-
-                        } else {
-                            do_request( retry_options );
-                        }
-
-                    } else {
-                        result.id = 'HTTP_' + status_code;
-                        result.message = http_.STATUS_CODES[ status_code ];
-
-                        let log_message = status_code + total();
-                        if ( result.body ) {
-                            log_message += ': ' + String( result.body );
-                        }
-                        log_message += ' ' + log_url;
-
-                        context.error( log_message );
-                        do_fail( result );
-                    }
-
-                    if ( status_code >= 500 && req && req.socket ) {
-                        //  Удаляем сокет, чтобы не залипать на отвечающем ошибкой бекэнде.
-                        req.socket.destroy();
-                    }
-
+                if ( do_retry( status_code, headers ) ) {
                     return;
                 }
 
@@ -443,6 +419,10 @@ de.request = function( options, context ) {
         } );
 
         req.on( 'error', function( error ) {
+            if ( req.aborted ) {
+                //  FIXME: правда ли нет ситуация, когда это приведет к повисанию запроса?
+                return;
+            }
             if ( promise.is_resolved() ) {
                 return;
             }
@@ -455,9 +435,7 @@ de.request = function( options, context ) {
             context.error( 'UNKNOWN_ERROR' + total() + ': ' + error.message );
             do_fail( result );
 
-            if ( req && req.socket ) {
-                req.socket.destroy();
-            }
+            destroy_request_socket();
         } );
 
         if ( data ) {
@@ -465,6 +443,65 @@ de.request = function( options, context ) {
         }
 
         req.end();
+
+        function do_retry( status_code = 0, headers = {} ) {
+            if ( is_error( status_code, headers ) ) {
+                if ( request_options.retries < max_retries && is_retry_allowed( status_code, headers ) ) {
+                    let log_message = status_code + in_ms( timestamps.start );
+                    if ( result.body ) {
+                        log_message += ' ' + String( result.body );
+                    }
+                    log_message += ' ' + log_url;
+                    context.warn( log_message );
+
+                    //  копируем options из оригинального вызова do_request,
+                    //  потому что request_options с ними не совпадают.
+                    const retry_options = no.extend( {}, options );
+                    retry_options.retries++;
+                    retries++;
+
+                    if ( retry_timeout > 0 ) {
+                        setTimeout(
+                            function() {
+                                do_request( retry_options );
+                            },
+                            retry_timeout
+                        );
+
+                    } else {
+                        do_request( retry_options );
+                    }
+
+                } else {
+                    result.id = 'HTTP_' + status_code;
+                    result.message = http_.STATUS_CODES[ status_code ];
+
+                    let log_message = status_code + total();
+                    if ( result.body ) {
+                        log_message += ': ' + String( result.body );
+                    }
+                    log_message += ' ' + log_url;
+
+                    context.error( log_message );
+                    do_fail( result );
+                }
+
+                if ( status_code >= 500 ) {
+                    //  Удаляем сокет, чтобы не залипать на отвечающем ошибкой бекэнде.
+                    destroy_request_socket();
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    function destroy_request_socket() {
+        if ( req && req.socket ) {
+            req.socket.destroy();
+        }
     }
 
     function total() {

--- a/lib/de.request.js
+++ b/lib/de.request.js
@@ -314,6 +314,11 @@ de.request = function( options, context ) {
             let received_length = 0;
             //
             res.on( 'data', function( data ) {
+                if ( req.aborted ) {
+                    //  Не обрабатываем входящие данные, если запрос оборван
+                    return;
+                }
+
                 buffers.push( data );
                 received_length += data.length;
             } );
@@ -323,6 +328,10 @@ de.request = function( options, context ) {
 
             res.on( 'end', function() {
                 timestamps.end = Date.now();
+                if ( req.aborted ) {
+                    //  Не обрабатываем ответ, если запрос оборван
+                    return;
+                }
 
                 result.body = ( received_length ) ? Buffer.concat( buffers, received_length ).toString() : null;
 
@@ -384,7 +393,8 @@ de.request = function( options, context ) {
             } );
 
             res.on( 'close', function( error ) {
-                if ( promise.is_resolved() ) {
+                if ( promise.is_resolved() || req.aborted ) {
+                    //  Не обрабатываем ответ, если запрос оборван
                     return;
                 }
 


### PR DESCRIPTION
Раньше перезапросы были только в случае неудачного ответа (например, 500).
Перенес обработку перезапросов в функцию и заиспользовал ее в обработке таймаутов.