### PR TITLE
В случае HTTP 429 надо делать перезапрос

### DIFF
--- a/lib/de.request.js
+++ b/lib/de.request.js
@@ -28,6 +28,7 @@ const DEFAULT_OPTIONS = {
     is_retry_allowed: function( status_code, headers ) {
         return (
             status_code === 408 ||
+            status_code === 429 ||
             status_code === 500 ||
             ( status_code >= 502 && status_code <= 504 )
         );


### PR DESCRIPTION
Если сервер отвечает HTTP 429 (Too many request), то надо это расценивать как ошибку и делать перезапрос.