### PR TITLE
error in close event may be missing

### DIFF
--- a/lib/de.request.js
+++ b/lib/de.request.js
@@ -194,7 +194,7 @@ de.request = function( options, context ) {
 
                 error = {
                     id: de.Error.ID.HTTP_CONNECTION_CLOSED,
-                    message: error.message,
+                    message: error ? error.message : 'UNEXPECTED_RESPONSE_CLOSED',
                 };
                 do_fail( error, request_options );
             } );


### PR DESCRIPTION
Stacktrace

TypeError: Cannot read property 'message' of undefined
  at IncomingMessage.<anonymous> (/descript2/lib/de.request.js:199:36)
  at IncomingMessage.emit (events.js:194:15)
  at Socket.socketCloseListener (_http_client.js:356:11)
  at Socket.emit (events.js:194:15)
  at TCP._handle.close (net.js:600:12)